### PR TITLE
Fixed Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 
@@ -9,21 +8,17 @@ env:
   - TESTER_PHP_BIN="php-cgi"
 
 before_install:
-  - composer self-update
+  # @todo: Temporary downgrade Composer to the version 1.x, related issue https://github.com/wikimedia/composer-merge-plugin/pull/189
+  - composer self-update --1
+
+script:
+  - composer run tests
 
 after_failure:
   - for i in $(find ./tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
 
 jobs:
   include:
-    -   name: Highest Dependencies
-        script:
-          - composer run tests:highest
-
-    -   name: Lowest Dependencies
-        script:
-          - composer run tests:lowest
-
     -   name: Nette Code Checker
         install:
           - travis_retry composer create-project nette/code-checker temp/code-checker ~3.2 --no-progress
@@ -31,10 +26,15 @@ jobs:
           - php temp/code-checker/code-checker --strict-types --short-arrays
 
     -   name: Php-Cs-Fixer
+        install:
+          - travis_retry composer install --no-progress --prefer-dist
         script:
           - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run
 
     -   stage: Code Coverage
+        install:
+          - travis_retry composer install --no-progress --prefer-dist
+          - travis_retry composer bin all install --no-progress --prefer-dist
         script:
           - vendor/bin/tester -p phpdbg tests -s --coverage ./coverage.xml --coverage-src ./src -d zend_extension=xdebug.so
         after_script:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,10 +8,10 @@ Copyright (c) 2020 '68 Publishers
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A package contains bridges for the most used integrations of [doctrine/orm](http
 - [Nettrine](https://github.com/nettrine)
 
 Bridges for this integrations will be implemented in the future:
+
 - [Kdyby](https://github.com/Kdyby/Doctrine) (missing support for Nette 3)
 
 Why? Because we want to keep our bundles independent from specific integrations so applications can use any of the integrations mentioned above and will be still compatible with our bundles.
@@ -43,7 +44,7 @@ use SixtyEightPublishers\DoctrineBridge\DI\DatabaseType;
 use SixtyEightPublishers\DoctrineBridge\DI\DatabaseTypeProviderInterface;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
-class FooExtension extends CompilerExtension implements DatabaseTypeProviderInterface 
+class FooExtension extends CompilerExtension implements DatabaseTypeProviderInterface
 {
     public function getDatabaseTypes() : array
     {

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
 		}
 	],
 	"require": {
-		"php": "^7.2",
+		"php": "^7.3",
 		"nette/di": "^3.0.3"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",
 		"friendsofphp/php-cs-fixer": "^2.0",
 		"nette/bootstrap": "^3.0",
-		"nette/tester": "^2.0",
+		"nette/tester": "^2.3.4",
 		"roave/security-advisories": "dev-master"
 	},
 	"suggest": {
@@ -41,7 +41,15 @@
 			"@tests:lowest",
 			"@tests:highest"
 		],
-		"tests:lowest" : "composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable && composer bin all update --no-progress --prefer-dist --prefer-lowest --prefer-stable && vendor/bin/tester ./tests",
-		"tests:highest" : "composer update --no-progress --prefer-dist --prefer-stable && composer bin all update --no-progress --prefer-dist --prefer-stable && vendor/bin/tester ./tests"
+		"tests:lowest" : [
+			"@composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable",
+			"@composer bin all update --no-progress --prefer-dist --prefer-lowest --prefer-stable",
+			"vendor/bin/tester ./tests"
+		],
+		"tests:highest" : [
+			"@composer update --no-progress --prefer-dist --prefer-stable",
+			"@composer bin all update --no-progress --prefer-dist --prefer-stable",
+			"vendor/bin/tester ./tests"
+		]
 	}
 }

--- a/vendor-bin/nettrine/composer.json
+++ b/vendor-bin/nettrine/composer.json
@@ -1,10 +1,10 @@
 {
-    "require": {
-        "theofidry/composer-inheritance-plugin": "^1.0",
-        "nettrine/orm": "^0.7"
-    },
-    "config": {
-        "bin-dir": "bin",
-        "sort-packages": true
-    }
+	"require": {
+		"theofidry/composer-inheritance-plugin": "^1.0",
+		"nettrine/orm": "^0.7"
+	},
+	"config": {
+		"bin-dir": "bin",
+		"sort-packages": true
+	}
 }


### PR DESCRIPTION
- modified Travis configuration
- changed minimal required PHP version to `7.3`
- changed minimal required version of `nette/tester` to `2.3.4`
- added tabs indentation in `vendor-bin` composers
- removed whitespaces from LICENSE and README